### PR TITLE
Fallback when no application language found

### DIFF
--- a/lib/i18n/backend/tml.rb
+++ b/lib/i18n/backend/tml.rb
@@ -90,7 +90,7 @@ module I18n
           target_language = application.language(locale.to_s)
 
           # if target language not set, return default locale
-          return tranlsation unless target_language
+          return translation unless target_language
 
           if translation.is_a?(String)
             translation = target_language.translate(convert_to_tml(translation), options, options)

--- a/lib/i18n/backend/tml.rb
+++ b/lib/i18n/backend/tml.rb
@@ -89,6 +89,9 @@ module I18n
           # if language is not available, return default value
           target_language = application.language(locale.to_s)
 
+          # if target language not set, return default locale
+          return tranlsation unless target_language
+
           if translation.is_a?(String)
             translation = target_language.translate(convert_to_tml(translation), options, options)
           elsif translation.is_a?(Hash)

--- a/lib/tml/cache_adapters/rails.rb
+++ b/lib/tml/cache_adapters/rails.rb
@@ -64,8 +64,12 @@ class Tml::CacheAdapters::Rails < Tml::Cache
   end
 
   def store(key, data, opts = {})
-    info("Cache store: #{key}")
-    @cache.write(versioned_key(key, opts), strip_extensions(data))
+    if data.try(:[], 'version').to_i != 0
+      info("Cache store: #{key}")
+      @cache.write(versioned_key(key, opts), strip_extensions(data))
+    else
+      info("Cache store error: No data to store")
+    end
     data
   rescue Exception => ex
     warn("Failed to store data: #{ex.message}")


### PR DESCRIPTION
# What
When using `I18n.backend = I18n::Backend::Tml.new` and `ActiveAdmin`
an application is not able to start (throws an error on server boot)

# Investigation
For some cases when we attempt to translate before triggering ActionControllerExtension `tml_init`. This will result in application returning `nil` as a language.

This is the case when you're using tools like for example ActiveAdmin which does not rely on ActionController.

# Solution
If you're using ActiveAdmin you will not see loaded translations at this point but an application will not blow up which sounds like a good solution for now.